### PR TITLE
Added additional catch for cast-xmr hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Using python 3.6
 Install python 3.6
 Install the python module requirments (pip install -r requirements.txt)
 
+For debugging & development, I have created a lite server which simulates the cast server on localhost:7777. You need python-flask in order to use this.
+
 CONFIG LOCATION
 ===============
 - Make a copy of exampleconfig.yaml, and name it config.yaml.	Update this with your settings. Put which miner you use, file paths, etc

--- a/castSim.py
+++ b/castSim.py
@@ -1,0 +1,95 @@
+#import the test libs to simulate the cast server
+from flask import Flask
+import json
+import time
+import random
+
+mode = 'normal' #normal, lowhash, online0, samehash 
+hashThreshold = 3650*1000
+hashrate = hashThreshold + 200000
+
+data = json.loads('''{
+    "total_hash_rate": 3718861,
+    "total_hash_rate_avg": 3850839,
+    "pool": {
+        "server": "cryptonight.usa.nicehash.com:3355",
+        "status": "connected",
+        "online": 589,
+        "offline": 0,
+        "reconnects": 0,
+        "time_connected": "2018-03-25 21:11:17",
+        "time_disconnected": "2018-03-25 21:11:17"
+    },
+    "job": {
+        "job_number": 10,
+        "difficulty": 200007,
+        "running": 26,
+        "job_time_avg": 62.44
+    },
+    "shares": {
+        "num_accepted": 18,
+        "num_rejected": 0,
+        "num_invalid": 1,
+        "num_network_fail": 0,
+        "num_outdated": 0,
+        "search_time_avg": 32.56
+    },
+    "devices": [
+    {
+        "device": "GPU0",
+        "device_id": 0,
+        "hash_rate": 1905402,
+        "hash_rate_avg": 2044244,
+        "gpu_temperature": 59,
+        "gpu_fan_rpm": 3881
+    },
+    {
+        "device": "GPU1",
+        "device_id": 1,
+        "hash_rate": 1813459,
+        "hash_rate_avg": 1806595,
+        "gpu_temperature": 60,
+        "gpu_fan_rpm": 3412
+    }
+    ]
+}''')
+
+start = time.time()
+
+# Setup Flask app and app.config
+app = Flask(__name__)
+
+@app.route('/')
+def castSim():
+    if mode == 'normal':
+        #normal operation: online increases, hashrate is above minimum
+        online = time.time() - start
+        data['pool']['online'] = int(online)
+        data['total_hash_rate'] = hashrate + random.randint(-50000, 50000)
+        data['total_hash_rate_avg'] = hashrate + random.randint(-5000, 5000)
+
+    elif mode == 'lowhash':
+        #simulate low hashrate
+        online = time.time() - start
+        data['pool']['online'] = int(online)
+        data['total_hash_rate'] = hashThreshold + random.randint(-50000, 50000)
+        data['total_hash_rate_avg'] = hashThreshold + random.randint(-5000, 5000)
+
+    elif mode == 'online0':
+        #simulate online time of zero
+        data['pool']['online'] = 0
+        data['total_hash_rate'] = hashrate + random.randint(-50000, 50000)
+        data['total_hash_rate_avg'] = hashrate + random.randint(-5000, 5000)
+        pass
+
+    elif mode == 'samehash':
+        #simulate identical hashrates
+        online = time.time() - start
+        data['pool']['online'] = int(online)
+        data['total_hash_rate'] = hashrate
+        data['total_hash_rate_avg'] = hashrate
+        pass
+
+    return json.dumps(data)
+
+app.run(host='0.0.0.0', port=7777, debug=True)

--- a/castSim.py
+++ b/castSim.py
@@ -4,7 +4,7 @@ import json
 import time
 import random
 
-mode = 'normal' #normal, lowhash, online0, samehash 
+mode = 'normal' #normal, lowhash, online0, samehash, rejected
 hashThreshold = 3650*1000
 hashrate = hashThreshold + 200000
 
@@ -29,7 +29,7 @@ data = json.loads('''{
     "shares": {
         "num_accepted": 18,
         "num_rejected": 0,
-        "num_invalid": 1,
+        "num_invalid": 0,
         "num_network_fail": 0,
         "num_outdated": 0,
         "search_time_avg": 32.56
@@ -88,6 +88,15 @@ def castSim():
         data['pool']['online'] = int(online)
         data['total_hash_rate'] = hashrate
         data['total_hash_rate_avg'] = hashrate
+        pass
+    
+    elif mode == 'rejected':
+        #simulate rejected shares
+        num_invalid = data['shares']['num_invalid'] + 1
+        online = time.time() - start
+        data['pool']['online'] = int(online)
+        data['total_hash_rate'] = hashrate + random.randint(-50000, 50000)
+        data['total_hash_rate_avg'] = hashrate + random.randint(-5000, 5000)
         pass
 
     return json.dumps(data)

--- a/castSim.py
+++ b/castSim.py
@@ -5,7 +5,7 @@ import time
 import random
 from copy import deepcopy
 
-mode = 'crash' #normal, lowhash, online0, samehash, rejected, crash
+mode = 'normal' #normal, lowhash, online0, samehash, rejected, crash
 hashThreshold = 5850*1000
 hashrate = hashThreshold + 200000
 numGPU = 3
@@ -47,8 +47,6 @@ start = time.time()
 app = Flask(__name__)
 
 def startGPUs():
-    print "starting GPUs"
-
     for x in range(numGPU):
         #build gpu data
         GPU = {"device": "GPU" + str(x),
@@ -74,7 +72,7 @@ def castSim():
     else:
         updateGPUs()
 
-    if mode == 'normal':
+    if mode == 'normal' or mode == 'crash':
         #normal operation: online increases, hashrate is above minimum
         online = time.time() - start
         data['pool']['online'] = int(online)

--- a/exampleconfig.yaml
+++ b/exampleconfig.yaml
@@ -1,7 +1,9 @@
 global:
+  context: 'live' #test or live
   app: 'XMR' #XMR or CAST
   hashthreshold: 3700
   timethreshold: 10
+  logsamples: 10
   devconpath: "C:\\users\\YOURUSER\\desktop\\devcon.exe"
   overdrivepath: "C:\\users\\YOURUSER\\desktop\\overdriventool.exe"
   overdriveargs: '-p1Stable -p2Stable'
@@ -16,3 +18,7 @@ castxmr:
   procname: "cast_xmr-vega.exe"
   castargs: "-S pool.supportxmr.com:7777 -u WALLETADDRESS --opencl 1 -p rigGPU:YOUREMAIL -G 0,1 -R"
   url: "http://localhost:7777/"
+
+actions:
+  applyoverdrive: True
+  restartdivers: False

--- a/exampleconfig.yaml
+++ b/exampleconfig.yaml
@@ -16,7 +16,8 @@ xmr-stak:
 castxmr:
   path: "C:\\users\\YOURUSER\\desktop\\Release"
   procname: "cast_xmr-vega.exe"
-  castargs: "-S pool.supportxmr.com:7777 -u WALLETADDRESS --opencl 1 -p rigGPU:YOUREMAIL -G 0,1 -R"
+  scriptname: "some_start_script.bat" #script containing the start command for cast, looks like below
+  #castargs: "-S pool.supportxmr.com:7777 -u WALLETADDRESS --opencl 1 -p rigGPU:YOUREMAIL -G 0,1 -R"
   url: "http://localhost:7777/"
 
 actions:

--- a/exampleconfig.yaml
+++ b/exampleconfig.yaml
@@ -4,6 +4,7 @@ global:
   hashthreshold: 3700
   timethreshold: 10
   logsamples: 10
+  rejectedshares: 20
   devconpath: "C:\\users\\YOURUSER\\desktop\\devcon.exe"
   overdrivepath: "C:\\users\\YOURUSER\\desktop\\overdriventool.exe"
   overdriveargs: '-p1Stable -p2Stable'

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -296,7 +296,7 @@ def castXMRCheck():
 
             elif crashedGPU() is not None:
                 print(bcolors.FAIL + 'GPU{} has crashed! Resetting all miner settings'.format(crashedGPU()) + bcolors.ENDC)
-                restartreason += "\n{} - GPU{} crash".format(now, crashedGPU())
+                restartreason += "\n{} - GPU{} Crash".format(now, crashedGPU())
                 restartMiner()
 
             elif checkEqual(metrics['onlinetime']):

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -283,6 +283,7 @@ def castXMRCheck():
             return
 
         else:
+            print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(movingAverage(metrics['hashrate'], response.status_code) + bcolors.ENDC)
             if movingAverage(metrics['hashrate']) < hashthreshold:
                 print(bcolors.FAIL + 'SMA Hashrate is below set threshold! Resetting all miner settings' + bcolors.ENDC)
                 restartreason += "\n{} - Low Hashrate ({} H/s)".format(now, movingAverage(metrics['hashrate']))
@@ -307,8 +308,6 @@ def castXMRCheck():
                 print(bcolors.FAIL + 'Rejected shares threshold reached! Resetting all miner settings'.format(currenthash, hashthreshold) + bcolors.ENDC)
                 restartreason += "\n{} - Too many rejected shares".format(now)
                 restartMiner()
-
-        print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(movingAverage(metrics['hashrate'], response.status_code) + bcolors.ENDC)
 
 if __name__ == '__main__':
     while True:

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -212,6 +212,7 @@ def XMRStakCheck():
 
 def castXMRCheck():
     global restartreason
+    printed = False
 
     try:
         response = requests.get(url)
@@ -230,6 +231,7 @@ def castXMRCheck():
     else:
         loaded = json.loads(response.text)
         currenthash = loaded['total_hash_rate'] / 1000
+        numGPU = loaded["devices"]
 
         #tracker for 'online' minutes
         online = loaded['pool']['online']
@@ -249,7 +251,10 @@ def castXMRCheck():
 
         if not warmupReached(metrics['hashrate']):
             #moving average is not accurate yet, so return.
-            print('SMA is not ready yet. Waiting...' + bcolors.ENDC)
+            if not printed:
+                print('SMA is not ready yet. Waiting.')
+            else:
+                print('.')
             return
 
         else:

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -283,7 +283,7 @@ def castXMRCheck():
             return
 
         else:
-            print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(movingAverage(metrics['hashrate'], response.status_code) + bcolors.ENDC)
+            print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(movingAverage(metrics['hashrate'], response.status_code) + bcolors.ENDC))
             if movingAverage(metrics['hashrate']) < hashthreshold:
                 print(bcolors.FAIL + 'SMA Hashrate is below set threshold! Resetting all miner settings' + bcolors.ENDC)
                 restartreason += "\n{} - Low Hashrate ({} H/s)".format(now, movingAverage(metrics['hashrate']))

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -17,8 +17,26 @@ overdrivepath = cfg['global']['overdrivepath']
 overdriveargs = cfg['global']['overdriveargs']
 timethreshold = cfg['global']['timethreshold']
 hashthreshold = cfg['global']['hashthreshold']
+logsamples = cfg['global']['logsamples']
 pattern = "Totals:\s+[0-9]+\.[0-9]+\s([0-9]+).*$"
+
+applyoverdrive = cfg['actions']['applyoverdrive']
+restartdivers = cfg['actions']['restartdivers']
+
 restartreason = ""
+devMode = False
+
+metrics = {'hashrate': [], 'onlinetime': []}
+
+if 'test' in cfg['global']['context']:
+    print "!!! RUNNING IN DEVELOPMENT MODE !!!"
+    devMode = True
+
+if restartdivers:
+    print "Configured to reset drivers on restart."
+
+if applyoverdrive:
+    print "Configured to apply overdrive settings on restart."
 
 if 'XMR' in cfg['global']['app']:
     app = 'XMR'
@@ -30,19 +48,41 @@ if 'CAST' in cfg['global']['app']:
     app = 'CAST'
     path = cfg['castxmr']['path']
     procname=  cfg['castxmr']['procname']
-    castargs = cfg['castxmr']['castargs']
+    scriptname = cfg['castxmr']['scriptname']
     url = cfg['castxmr']['url']
 
-
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+    if devMode:
+        HEADER = ''
+        OKBLUE = ''
+        OKGREEN = ''
+        WARNING = ''
+        FAIL = ''
+        ENDC = ''
+        BOLD = ''
+        UNDERLINE = ''
+    else:
+        HEADER = '\033[95m'
+        OKBLUE = '\033[94m'
+        OKGREEN = '\033[92m'
+        WARNING = '\033[93m'
+        FAIL = '\033[91m'
+        ENDC = '\033[0m'
+        BOLD = '\033[1m'
+        UNDERLINE = '\033[4m'
+
+def warmupReached(arr):
+    return len(arr) >= logsamples
+
+def movingAverage(arr):
+    return sum(arr)/len(arr)
+
+def log(arr, sample):
+    arr.append(sample)
+
+    if len(arr) > logsamples:
+        #pop the oldest reading off the beginning of the list
+        arr.pop(0)
 
 def tail(filename, pattern, maxlines=60):
     global restartreason
@@ -55,16 +95,18 @@ def tail(filename, pattern, maxlines=60):
                 #I dont want to scan old logs. So break this loop if before we go too deep.
                 if lines > maxlines:
                     continue
+
                 if 'Totals' in l:
                     hashrate = re.search(pattern, l)
                     if hashrate:
                         return hashrate.group(1)
+
         print(bcolors.WARNING + "No 60s hash found yet. Waiting for that to appear.. ({})".format(waitcount) + bcolors.ENDC)
         waitcount += 1
         if waitcount > 31:
             print(bcolors.FAIL + "Waited too long for an average hash! Kill it all." + bcolors.ENDC)
             restartreason += "{} - Timeout waiting for 60s Hash".format(now)
-            restarttime()
+            restartMiner()
             waitcount = 0
         time.sleep(10)
 
@@ -75,20 +117,24 @@ def mtime(logfile, timethreshold):
     diff = (lastmtime - cutoff) / datetime.timedelta(minutes=1)
     if diff < (timethreshold / 2):
         print(bcolors.WARNING + "Potential restart incoming. {} minutes until we deem stale".format(diff) + bcolors.ENDC)
+
     else:
         print("Logfile timeout countdown {} minutes".format(diff))
+
     if lastmtime > cutoff:
         #The file is updating actively
+
         return True
     else:
+
         #File stopped updating.
         return False
 
-def stopprocess(procname):
+def stopProcess(procname):
     r = os.system('taskkill /f /im {}'.format(procname))
     print('Killing {} returned {}'.format(procname, r))
 
-def resetdrivers(devconpath):
+def resetDrivers(devconpath):
     #reset the drivers using devcon. Note this currently is using the CWD of the script, so it needs to be in the same location as this python script
     print('Resetting Drivers')
     r = subprocess.Popen('{} restart "PCI\VEN_1002&DEV_687F*"'.format(devconpath))
@@ -99,108 +145,144 @@ def overdrive(overdrivepath, overdriveargs):
     print('Applying Overdrive configs')
     r = subprocess.Popen('{} {}'.format(overdrivepath, overdriveargs), shell=True)
 
-def startmining(path, procname):
+def startMining(path, procname):
     if "XMR" in app:
         print('Spinning up XMR-stak\n')
         subprocess.Popen('start cmd /C "{}\{}"'.format(path, procname), shell=True)
+
     if "CAST" in app:
         print('Spinning up Cast-XMR\n')
-        subprocess.Popen('start cmd /C "{}\{} {}"'.format(path, procname, castargs), shell=True)
+        subprocess.Popen('start cmd /C "{}\{}"'.format(path, scriptname), shell=True)
 
-def restarttime():
-    stopprocess(procname)
-    time.sleep(4)
-    try:
-        os.remove(logfile)
-    except (OSError, NameError) as e:
+def restartMiner():
+    #clear the metrics
+    global metrics
+    metrics = {'hashrate': [], 'onlinetime': []}
+
+    if devMode:
         pass
-    resetdrivers(devconpath)
-    overdrive(overdrivepath, overdriveargs)
-    os.chdir(path)
-    startmining(path, procname)
-    print('Waiting 120 seconds to get new average hash rates...')
-    time.sleep(120)
 
-def xmrstakcheck():
+    else:
+        stopProcess(procname)
+        time.sleep(4)
+        try:
+            os.remove(logfile)
+
+        except (OSError, NameError) as e:
+            pass
+
+        if restartdivers:
+            resetDrivers(devconpath)
+
+        if applyoverdrive:
+            overdrive(overdrivepath, overdriveargs)
+
+        os.chdir(path)
+        startMining(path, procname)
+
+def checkEqual(lst):
+   return lst[1:] == lst[:-1]
+
+def XMRStakCheck():
     global restartreason
     if os.path.exists(logfile):
         currenthash = tail(logfile, pattern)
+        log(metrics['hashrate'], currenthash)
+
         updating = mtime(logfile, timethreshold)
-        if int(currenthash) < hashthreshold:
-            print(bcolors.FAIL + 'Hashrate of {} is below set threshold of {}! Resetting all miner settings'.format(currenthash, hashthreshold) + bcolors.ENDC)
-            restarttime()
-            restartreason += "\ns{} - Low Hashrate ({} H/s)".format(now, currenthash)
-        if updating == False:
-            print(bcolors.FAIL + 'The logfile ({}) hasn\'t been updating for {} minutes. Restart sequence beginning'.format(logfile, timethreshold) + bcolors.ENDC)
-            restarttime()
-            restartreason += "\n{} - Logfile timeout".format(now)
+
+        if not warmupReached(metrics['hashrate']):
+            #moving average is not accurate yet, so return.
+            print('SMA is not ready yet. Waiting...' + bcolors.ENDC)
+            return
+
+        else:
+            if movingAverage(metrics['hashrate']) < hashthreshold:
+                print(bcolors.FAIL + 'Hashrate of {}H/s is below set threshold of {}! Resetting all miner settings'.format(movingAverage(metrics['hashrate']), hashthreshold) + bcolors.ENDC)
+                restartreason += "\n{} - Low Hashrate ({} H/s)".format(now, movingAverage(metrics['hashrate']))
+                restartMiner()
+
+            if updating == False:
+                print(bcolors.FAIL + 'The logfile ({}) hasn\'t been updating for {} minutes. Restart sequence beginning'.format(logfile, timethreshold) + bcolors.ENDC)
+                restartreason += "\n{} - Logfile timeout".format(now)
+                restartMiner()
+
     print(bcolors.OKGREEN + 'Hashrate: {}H/s\nLog updating: {}\n'.format(currenthash, updating) + bcolors.ENDC)
 
-def castcheck():
+def castXMRCheck():
     global restartreason
+
     try:
         response = requests.get(url)
+
     except:
         print(bcolors.FAIL + 'Local webserver threw exception. Is CastXMR down? Restarting just in case.' + bcolors.ENDC)
-        restarttime()
-        restartreason += "{} - Webserver caught exception".format(now)
+        restartMiner()
+        restartreason += "{} - Webserver caught exception\n".format(now)
         return
+
     if response.status_code > 300:
         print(bcolors.FAIL + 'Local webserver returned {}. Is CastXMR down? Restarting just in case.'.format(response.status_code) + bcolors.ENDC)
-        restarttime()
+        restartMiner()
         restartreason += "{} - Web return {}".format(now, response.status_code)
+
     else:
         loaded = json.loads(response.text)
-        #interesting conversion. Perhaps this is why cast seems to have higher values than other miners?
         currenthash = loaded['total_hash_rate'] / 1000
+
         #tracker for 'online' minutes
         online = loaded['pool']['online']
 
-        if currenthash < hashthreshold or online == 0:
-            print(bcolors.WARNING + 'Hashrate of {}H/s is below threshold, or miner is offline. Grabbing a 60s average.'.format(currenthash) + bcolors.ENDC)
-            hash = 0
-            on = 0
-            for count in range(1, 7):
-                time.sleep(10)
-                #since i do 10 second intervals,
+        #use new SMA method
+        log(metrics['hashrate'], currenthash)
+        log(metrics['onlinetime'], online)
 
-                try:
-                    response = requests.get(url)
-                    loaded = json.loads(response.text)
+        if devMode:
+            print 'hashrate moving average:', movingAverage(metrics['hashrate'])
+            print 'hashrate array:', metrics['hashrate']
+            print 'online array:', metrics['onlinetime']
 
-                except:
-                    #assume exceptions are caused by issues anyways. Let it continue and restart
-                    pass
+        if not warmupReached(metrics['hashrate']):
+            #moving average is not accurate yet, so return.
+            print('SMA is not ready yet. Waiting...' + bcolors.ENDC)
+            return
 
-                h = loaded['total_hash_rate'] / 1000
-                o = loaded['pool']['online']
+        else:
+            if movingAverage(metrics['hashrate']) < hashthreshold:
+                print(bcolors.FAIL + 'SMA Hashrate is below set threshold! Resetting all miner settings' + bcolors.ENDC)
+                restartreason += "\n{} - Low Hashrate ({} H/s)".format(now, movingAverage(metrics['hashrate']))
+                restartMiner()
 
-                hash += h
-                on += o
-                print(bcolors.WARNING + 'Checking {}/6 hashrate: {}H/s'.format(count, h) + bcolors.ENDC)
-                print(bcolors.WARNING + 'Checking {}/6 online: {} seconds'.format(count, o) + bcolors.ENDC)
+            elif checkEqual(metrics['hashrate']):
+                print(bcolors.FAIL + 'Hashrate is the same across all samples! Resetting all miner settings'.format(currenthash, hashthreshold) + bcolors.ENDC)
+                restartreason += "\n{} - Identical hashrate -- likely CastXMR hang".format(now)
+                restartMiner()
 
-            #take the 60s average and fire a restart if it's below
-            if (hash/6) < hashthreshold:
-                print(bcolors.FAIL + 'Hashrate of {}H/s is below set threshold of {}! Resetting all miner settings'.format(currenthash, hashthreshold) + bcolors.ENDC)
-                restarttime()
-                restartreason += "\n{} - Low Hashrate ({} H/s)".format(now, currenthash)
-
-            if (on) == 0:
+            elif checkEqual(metrics['onlinetime']):
                 print(bcolors.FAIL + 'Online time has been 0 for the past minute! Resetting all miner settings'.format(currenthash, hashthreshold) + bcolors.ENDC)
-                restarttime()
                 restartreason += "\n{} - Online time of zero -- likely CastXMR hang".format(now)
-                
+                restartMiner()
+
         print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(currenthash, response.status_code) + bcolors.ENDC)
 
-while True:
-    print(bcolors.BOLD + '\n\n==============\n' + bcolors.ENDC)
-    now = datetime.datetime.now()
-    if "XMR" in app:
-        xmrstakcheck()
-    if "CAST" in app:
-        castcheck()
-    if restartreason:
-        print(bcolors.BOLD + '======Reasons for Restarts======' + bcolors.ENDC)
-        print(bcolors.WARNING + '{}\n'.format(restartreason) + bcolors.ENDC)
-    time.sleep(10)
+if __name__ == '__main__':
+    while True:
+        print(bcolors.BOLD + '\n\n==============\n' + bcolors.ENDC)
+        now = datetime.datetime.now()
+
+        if "XMR" in app:
+            XMRStakCheck()
+
+        if "CAST" in app:
+            castXMRCheck()
+
+        if restartreason and warmupReached(metrics['hashrate']):
+            print(bcolors.BOLD + '======Reasons for Restarts======' + bcolors.ENDC)
+            print(bcolors.WARNING + '{}\n'.format(restartreason) + bcolors.ENDC)
+
+        if devMode:
+            #might as well speed this up
+            time.sleep(timethreshold/5)
+
+        else:
+            time.sleep(timethreshold)

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -232,9 +232,9 @@ def castXMRCheck():
         response = requests.get(url)
 
     except:
-        print(bcolors.FAIL + 'Local webserver threw exception. Is CastXMR down? Restarting just in case.' + bcolors.ENDC)
+        print(bcolors.FAIL + 'Local webserver threw exception.' + bcolors.ENDC)
         restartMiner()
-        restartreason += "\n{} - Webserver caught exception\n".format(now)
+        restartreason += "\n{} - Webserver caught exception".format(now)
         return
 
     if response.status_code > 300:
@@ -295,7 +295,7 @@ def castXMRCheck():
 
             elif crashedGPU() is not None:
                 print(bcolors.FAIL + 'GPU{} has crashed! Resetting all miner settings'.format(crashedGPU()) + bcolors.ENDC)
-                restartreason += "\n{} - Identical hashrate for GPU -- GPU{} crash".format(now, crashedGPU())
+                restartreason += "\n{} - GPU{} crash".format(now, crashedGPU())
                 restartMiner()
 
             elif checkEqual(metrics['onlinetime']):

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -253,6 +253,7 @@ def castXMRCheck():
             #moving average is not accurate yet, so return.
             if not printed:
                 print('SMA is not ready yet. Waiting.')
+                printed = True
             else:
                 print('.')
             return

--- a/vegamonitor.py
+++ b/vegamonitor.py
@@ -308,7 +308,7 @@ def castXMRCheck():
                 restartreason += "\n{} - Too many rejected shares".format(now)
                 restartMiner()
 
-        print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(currenthash, response.status_code) + bcolors.ENDC)
+        print(bcolors.OKGREEN + 'Hashrate: {}H/s\nWeb request returns: {}\n'.format(movingAverage(metrics['hashrate'], response.status_code) + bcolors.ENDC)
 
 if __name__ == '__main__':
     while True:


### PR DESCRIPTION
Cast-XMR has a strange failure mode that occurs once in a while where it hangs solid but the web server is still responsive. When this happens, the online seconds fall to 0 and do not change. This check ensures the online minutes aren't at zero throughout a 1 minute sample.